### PR TITLE
Fix example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Run TailwindCSS CLI [without needing](https://www.srid.ca/nojs) to touch anything JavaScript. No `input.css` or `tailwind.config.js` necessary.
 
 ```
-nix run github:srid/tailwind-haskell -- 'src/**/.hs' -o output.css
+nix run github:srid/tailwind-haskell -- 'src/**/*.hs' -o output.css
 ```
 
 Compiles CSS classes in those file paths or patterns, and writes `./tailwind.css`. Pass `-w` to run in JIT watcher mode.


### PR DESCRIPTION
The current example does not work. It emits warnings and does not produce an output:
```
warn - No utility classes were detected in your source files. If this is unexpected, double-check the `content` option in your Tailwind CSS configuration.
warn - https://tailwindcss.com/docs/content-configuration
```

The problem seems to be the glob pattern and changing it seems to produce the desired outcome.