### PR TITLE
Fix `default.nix` to actually work

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,8 @@
-# This file exists for legacy Nix installs (nix-build & nix-env)
-# https://nixos.wiki/wiki/Flakes#Using_flakes_project_from_a_legacy_Nix
-# You generally do *not* have to modify this ever.
 (import
   (
-    let
-      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-    in
     fetchTarball {
-      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-      sha256 = lock.nodes.flake-compat.locked.narHash;
+      url = "https://github.com/edolstra/flake-compat/archive/12c64ca55c1014cdc1b16ed5a804aa8576601ff2.tar.gz";
+      sha256 = "0jm6nzb83wa6ai17ly9fzpqc40wg1viib8klq8lby54agpl213w5";
     }
   )
   {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1652776076,
@@ -34,6 +50,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1652776076,
@@ -50,7 +34,6 @@
     },
     "root": {
       "inputs": {
-        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,12 +5,8 @@
     # https://github.com/srid/haskell-template/issues/64
     nixpkgs.url = "github:nixos/nixpkgs/0cfb3c002b61807ca0bab3efe514476bdf2e5478";
     flake-utils.url = "github:numtide/flake-utils/v1.0.0";
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
   };
-  outputs = inputs@{ self, nixpkgs, flake-utils, flake-compat, ... }:
+  outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs =

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,12 @@
     # https://github.com/srid/haskell-template/issues/64
     nixpkgs.url = "github:nixos/nixpkgs/0cfb3c002b61807ca0bab3efe514476bdf2e5478";
     flake-utils.url = "github:numtide/flake-utils/v1.0.0";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
-  outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
+  outputs = inputs@{ self, nixpkgs, flake-utils, flake-compat, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs =
@@ -30,7 +34,7 @@
             modifier = drv:
               pkgs.haskell.lib.addBuildTools drv
                 (with pkgs.haskellPackages; [
-                  # Specify your build/dev dependencies here. 
+                  # Specify your build/dev dependencies here.
                   cabal-fmt
                   cabal-install
                   ghcid


### PR DESCRIPTION
I needed to add `flake-compat` to actually use the `default.nix`. I am adding tailwind-haskell to a nixified haskell project that doesn't use flakes. cf. https://nixos.wiki/wiki/Flakes#Using_flakes_project_from_a_legacy_Nix